### PR TITLE
chore: upgrade trino to version 445

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM trinodb/trino:440
+FROM trinodb/trino:445
 
 COPY ./conf/catalog.properties /etc/trino/catalog.properties
 COPY ./conf/catalog/ /etc/trino/catalog/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ networks:
 
 services:
   trino:
-    image: trinodb/trino:440
+    image: trinodb/trino:445
     restart: unless-stopped
     env_file: .env
     init: true

--- a/infra/helm/trino/values.yaml
+++ b/infra/helm/trino/values.yaml
@@ -7,7 +7,7 @@ image:
   pullPolicy: Always
   # Overrides the image tag whose default is the chart version.
   # Same value as Chart.yaml#appVersion
-  tag: "438"
+  tag: "445"
 
 imagePullSecrets:
   - name: registry-credentials


### PR DESCRIPTION
## What type of PR is this?

- `chore`: Miscellaneous commits (e.g. modifying `.gitignore`)

## Summary

Upgrades Trino to version 445, allowing for time travel queries in the Delta Lake connector.

## How to test

1. Test if time travel queries work for Delta Tables
2. See if any of the breaking changes between versions `438` and `445` affected our deployments.

## References
[Delta Lake Time Travel Queries](https://trino.io/docs/current/connector/delta-lake.html#time-travel-queries)
[Trino Changelog](https://trino.io/docs/current/release.html)